### PR TITLE
docker script: weergave van falen van opstarten van containers

### DIFF
--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -3,6 +3,28 @@
 start_containers() {
     echo "Starting Docker Compose services..."
     docker compose up --build -d
+
+
+    # Wait a few seconds to allow containers to initialize
+    sleep 3
+
+    # Check for exited (failed) containers
+    failed_containers=$(docker compose ps --filter "status=exited" --format "{{.Name}}")
+
+    if [[ -n "$failed_containers" ]]; then
+        echo -e "\n⚠️  Some containers failed to start:"
+        echo "$failed_containers"
+        echo -e "\nLogs for failed containers:\n"
+
+        # Display logs for each failed container
+        for container in $failed_containers; do
+            echo "Logs for $container:"
+            docker compose logs --tail=20 "$container"
+            echo "----------------------"
+        done
+    else
+        echo "✅ All containers started successfully!"
+    fi
 }
 
 stop_containers() {


### PR DESCRIPTION
Als een container niet correct opstart, werd niks getoond en moet je manueel opvragen want het probleem is.
Ik heb het script aangepast zodat dit een fout geeft wanneer een container niet juist opstart en ook de logs ervan terug geeft.