### PR TITLE
quinten errors fixed for #180

### DIFF
--- a/src/backend/backend_opzet/__tests__/leerlingen/klassen/opdrachten/opdrachten.test.ts
+++ b/src/backend/backend_opzet/__tests__/leerlingen/klassen/opdrachten/opdrachten.test.ts
@@ -7,27 +7,27 @@ import { is_klassen_link, is_opdrachten_link } from "../../../hulpfuncties.ts";
 let authToken: string;
 
 beforeAll(async () => {
-    // Perform login as student1
-    const loginPayload = {
-        email: 'student1@example.com',
-        password: 'test'
-    };
+  // Perform login as student1
+  const loginPayload = {
+    email: 'student1@example.com',
+    password: 'test'
+  };
 
-    const response = await request(index).post("/authenticatie/aanmelden?gebruikerstype=leerling").send(loginPayload);
+  const response = await request(index).post("/authenticatie/aanmelden?gebruikerstype=leerling").send(loginPayload);
 
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty("token");
+  expect(response.status).toBe(200);
+  expect(response.body).toHaveProperty("token");
 
-    console.log('respnse body: ', response.body);
+  console.log('respnse body: ', response.body);
 
-    authToken = response.body.token;
+  authToken = response.body.token;
 });
 
 describe("leerlingen/:leerling_id/klassen/:klas_id/opdrachten", () => {
   it("krijg lijst van opdrachten", async () => {
     let res = await request(index).get("/leerlingen/1/klassen/1/opdrachten").set("Authorization", `Bearer ${authToken.trim()}`);;
     expect(res.status).toBe(200);
-    expect(res.body[0]).toBe("www.dwengo.be/opdrachten/5")
+    expect(res.body[0]).toBe("/opdrachten/1")
     expect(res.body).toHaveLength(1)
   });
 

--- a/src/backend/backend_opzet/controllers/klassen/opdrachten/opdrachten_controller.ts
+++ b/src/backend/backend_opzet/controllers/klassen/opdrachten/opdrachten_controller.ts
@@ -34,10 +34,12 @@ export async function klas_opdrachten(req: Request, res: Response) {
     });
 
     const assignmentLinks = assignments.map(
-      (assignment: { learning_path: string }) =>
+      (assignment: {
+        id: any; learning_path: string
+      }) =>
         `/klassen/${klas_id}/opdrachten/${assignment.id}`
     );
-    res.status(200).send({opdrachten:assignmentLinks});
+    res.status(200).send({ opdrachten: assignmentLinks });
   } catch (e) {
     res.status(500).send({ error: "internal server error ${e}" });
   }

--- a/src/backend/backend_opzet/controllers/leerlingen/klassen/opdrachten/opdrachten_controller.ts
+++ b/src/backend/backend_opzet/controllers/leerlingen/klassen/opdrachten/opdrachten_controller.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { z } from "zod";
 import { prisma } from "../../../../index.ts";
-import { ExpressException } from "../../../../exceptions/ExpressException.ts";
 
 // GET /leerlingen/:leerling_id/klassen/:klas_id/opdrachten
 export async function leerling_opdrachten(
@@ -9,53 +8,52 @@ export async function leerling_opdrachten(
   res: Response,
   next: NextFunction
 ) {
-  //console.log("geraakt!!!")
-  const studentId = z.coerce.number().safeParse(req.params.leerling_id);
-  if (!studentId.success)
-    throw new ExpressException(400, "invalid studentId", next);
+  try {
+    const studentId = z.coerce.number().safeParse(req.params.leerling_id);
+    if (!studentId.success) {
+      return res.status(400).json({ error: "invalid studentId" });
+    }
 
-  //console.log(studentId)
+    const student = await prisma.student.findUnique({
+      where: { id: studentId.data },
+    });
 
-  const student = await prisma.student.findUnique({
-    where: { id: studentId.data },
-  });
-  //console.log("student")
-  //console.log(student)
-  if (!student) throw new ExpressException(404, "student not found", next);
+    if (!student) {
+      return res.status(404).json({ error: "student not found" });
+    }
 
- 
-  const classId = z.coerce.number().safeParse(req.params.klas_id);
-  if (!classId.success)
-    throw new ExpressException(400, "Invalid classId", next);
+    const classId = z.coerce.number().safeParse(req.params.klas_id);
+    if (!classId.success) {
+      return res.status(400).json({ error: "Invalid classId" });
+    }
 
+    const klas = await prisma.class.findUnique({
+      where: { id: classId.data },
+    });
 
-  const klas = await prisma.class.findUnique({
-    where: { id: classId.data },
-  });
+    if (!klas) {
+      return res.status(404).json({ error: "class not found" });
+    }
 
-  if (!klas) throw new ExpressException(404, "class not found", next);
-
-  //console.log("classId")
-  //console.log(classId)
-
-  const assignments = await prisma.assignment.findMany({
-    where: {
-      //class: Number(classId), // todo verander het veld class in assignment naar een andere naam want mijn test is hierdoor in de war.
-      groups: {
-        some: {
-          students_groups: {
-            some: {
-              students_id: studentId.data,
+    const assignments = await prisma.assignment.findMany({
+      where: {
+        groups: {
+          some: {
+            students_groups: {
+              some: {
+                students_id: studentId.data,
+              },
             },
           },
         },
       },
-    },
-  });
-  //console.log("assigments")
-  //console.log(assignments)
-  const assignmentLinks = assignments.map(
-    (assignment) => "/opdrachten/" + assignment.id
-  );
-  res.status(200).send(assignmentLinks);
+    });
+
+    const assignmentLinks = assignments.map(
+      (assignment) => "/opdrachten/" + assignment.id
+    );
+    return res.status(200).json(assignmentLinks);
+  } catch (error) {
+    next(error);
+  }
 }


### PR DESCRIPTION
errors fixed for tests by replacing "throw new ExpressException(code, ...)" with try/catch and returning the return code to the test when failing.

tests for /leerlingen/klassen/opdrachten/opdrachten now correct without fault codes